### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -42,7 +42,7 @@ class LoginAnimationDemoState extends State<LoginAnimationDemo>{
                 var request = await httpClient.getUrl(Uri.parse(url));
                 var response = await request.close();
                 if (response.statusCode == HttpStatus.ok) {
-                  _result = await response.transform(utf8.decoder).join();
+                  _result = await utf8.decoder.bind(response)join();
 
                   //拿到数据后，对数据进行梳理
                   loginErrorMessageController.showErrorMessage("网络异常");


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
